### PR TITLE
Exception for empty encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,10 @@
         let morseLetters = value.split(/\s+/)
         let arrNormalLeters = []
         console.log(morseLetters)
+        if (arrNormalLeters.length === 0) {
+          alert("Please Enter A Message!");
+          throw "Please Enter A Message!";
+        }
         for (let j = 0; j < morseLetters.length; j++) {
           arrNormalLeters[j] = getByValue(langMap, morseLetters[j])
         }


### PR DESCRIPTION
exception only occurred when the decoding was empty